### PR TITLE
only reset the console for interactive terminals

### DIFF
--- a/src/runFlow.js
+++ b/src/runFlow.js
@@ -8,8 +8,12 @@ try {
   flow = 'flow'
 }
 
-process.stdout.write('\u001b[2J')
-process.stdout.write('\u001b[1;1H')
-process.stdout.write('\u001b[3J')
+// Only clear the console if it's an interactive terminal.
+if (process.stdout.isTTY) {
+  process.stdout.write('\u001b[2J')
+  process.stdout.write('\u001b[1;1H')
+  process.stdout.write('\u001b[3J')
+}
+
 require('child_process').spawn(flow, {stdio: 'inherit'})
 


### PR DESCRIPTION
Following the example [here](https://github.com/facebookincubator/create-react-app/pull/1032/files), I added the check to see if the running terminal is a TTY before trying to clear the console.