### PR TITLE
Watch .jsx files by default.

### DIFF
--- a/src/flow-watch.js
+++ b/src/flow-watch.js
@@ -13,6 +13,7 @@ spawn(
       : [
           '--ignore', 'node_modules/',
           '--watch', '*.js',
+          '--watch', '*.jsx',
           '--watch', '*.js.flow',
           '--watch', '.flowconfig',
         ],


### PR DESCRIPTION
I wager many people using flow may like to watch .jsx.  What do you think?