### PR TITLE
Add support for an env variable that tells flow-watch to not clear the console on every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ If you provide no arguments, it uses the following defaults:
 ```
 --ignore node_modules/ --watch *.js --watch *.jsx --watch *.js.flow --watch .flowconfig
 ```
+
+By default, the watcher will clear the console between each change. If you wish to override this behavior, use the `FLOW_WATCH_NO_CLEAR_CONSOLE` env variable. If you choose that approach, you may also want to silent the `[nodemon]` messages in the console, which you can do with the `--quiet` flag (or `-q`). Putting it all together:
+
+```json
+{
+  "scripts": {
+    "flow:watch": "FLOW_WATCH_NO_CLEAR_CONSOLE=1 flow-watch -q"
+  }
+}
+```

--- a/src/runFlow.js
+++ b/src/runFlow.js
@@ -8,12 +8,11 @@ try {
   flow = 'flow'
 }
 
-// Only clear the console if it's an interactive terminal.
-if (process.stdout.isTTY) {
+// Only clear the console if it's an interactive terminal & no env var override.
+if (process.stdout.isTTY && !process.env.FLOW_WATCH_NO_CLEAR_CONSOLE) {
   process.stdout.write('\u001b[2J')
   process.stdout.write('\u001b[1;1H')
   process.stdout.write('\u001b[3J')
 }
 
 require('cross-spawn')(flow, {stdio: 'inherit'})
-


### PR DESCRIPTION
I have a create-react-app-based app where I run flow-watch (with the `-q` flag) along with webpack-dev-server when running the `dev` npm run script. I’m pretty happy with the result, though it required disabling both CRA and flow-watch’s console clearing behavior in order to prevent them from trampling over each other as they run. Based on https://github.com/facebook/create-react-app/issues/2495, it seems there’s a significant contingent of users who need the option of not clearing the console on every update, so I figured I’d make this PR. Introduces a `FLOW_WATCH_PERSIST_CONSOLE` env variable to override the console clearing behavior. @jedwards1211 If you’d be willing to entertain the change, I’d be happy to add a note in the README about it, and happy of course to rename it if there’s something else you’d prefer.

Also, thanks for the package! It seems like a lot of people use flow and rely only on IDE integrations, but I find it indispensable to be able to see the entirety of a flow error, and see them not limited to the context of a single line in a single file, so this package was perfect for me.